### PR TITLE
README: Use `:bind` instead of general-define-key for wider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,16 @@ Currently you need to install from github via `package-vc` or
 (straight-use-package '(minuet :host github :repo "milanglacier/minuet-ai.el"))
 
 (use-package minuet
-    :init
-    (general-define-key
-     ;; use completion-in-region for completion
-     "M-y" #'minuet-completion-in-region
-     ;; use overlay for completion
-     "M-i" #'minuet-show-suggestion)
+    :bind (("M-y" . #'minuet-completion-in-region) ;; use completion-in-region for completion
+           ("M-i" . #'minuet-show-suggestion) ;; use overlay for completion
+           :map minuet-active-mode-map
+           ("M-p" . #'minuet-previous-suggestion) ;; invoke completion or cycle to next completion
+           ("M-n" . #'minuet-next-suggestion) ;; invoke completion or cycle to previous completion
+           ("M-A" . #'minuet-accept-suggestion) ;; accept whole completion
+           ("M-a" . #'minuet-accept-suggestion-line) ;; accept current line completion
+           ("M-e" . #'minuet-dismiss-suggestion))
 
+    :init
      ;; if you want to enable auto suggestion.
      ;; Note that you can manually invoke completions without enable minuet-auto-suggestion-mode
      (add-hook 'prog-mode-hook #'minuet-auto-suggestion-mode)
@@ -83,14 +86,6 @@ Currently you need to install from github via `package-vc` or
     ;; Required when defining minuet-ative-mode-map in insert/normal states.
     ;; Not required when defining minuet-active-mode-map without evil state.
     (add-hook 'minuet-active-mode-hook #'evil-normalize-keymaps)
-
-    (general-define-key
-     :keymaps 'minuet-active-mode-map
-     "M-p" #'minuet-previous-suggestion ;; invoke completion or cycle to next completion
-     "M-n" #'minuet-next-suggestion ;; invoke completion or cycle to previous completion
-     "M-A" #'minuet-accept-suggestion ;; accept whole completion
-     "M-a" #'minuet-accept-suggestion-line ;; accept current line completion
-     "M-e" #'minuet-dismiss-suggestion)
 
     (minuet-set-optional-options minuet-openai-fim-compatible-options :max_tokens 256))
 ```

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Currently you need to install from github via `package-vc` or
            ("M-e" . #'minuet-dismiss-suggestion))
 
     :init
-     ;; if you want to enable auto suggestion.
-     ;; Note that you can manually invoke completions without enable minuet-auto-suggestion-mode
-     (add-hook 'prog-mode-hook #'minuet-auto-suggestion-mode)
+    ;; if you want to enable auto suggestion.
+    ;; Note that you can manually invoke completions without enable minuet-auto-suggestion-mode
+    (add-hook 'prog-mode-hook #'minuet-auto-suggestion-mode)
 
     :config
     (setq minuet-provider 'openai-fim-compatible)


### PR DESCRIPTION
Users might not have `general.el` installed, so this makes it easier to get started.

Closes #5 