### PR TITLE
fim: keep result order when adding new result

### DIFF
--- a/minuet.el
+++ b/minuet.el
@@ -1047,8 +1047,9 @@ arrive."
            :then
            (lambda (json)
              (when-let* ((result (minuet--stream-decode json get-text-fn)))
-               ;; insert the current result into the completion items list
-               (push result completion-items))
+               ;; append the current result into the completion items list
+               ;; use append instead of push (to the front) to keep the order of the result, because the first result is already shown
+               (setq completion-items (append completion-items (list result))))
              (setq completion-items (minuet--filter-context-sequence-in-items
                                      completion-items
                                      context))
@@ -1060,7 +1061,7 @@ arrive."
                  (progn
                    (minuet--log (format "%s Request timeout" name))
                    (when-let* ((result (minuet--stream-decode-raw --response-- get-text-fn)))
-                     (push result completion-items)))
+                     (setq completion-items (append completion-items (list result)))))
                (minuet--log (format "An error occured when sending request to %s" name))
                (minuet--log err))
              (setq completion-items


### PR DESCRIPTION
Previously, when using FIM providers with multiple `minuet-n-completions`, the suggestion result would "flicker": the user may see "aaaaaa [1/1]" at first, then after a fraction of second it changed to "bbbbb [1/2]".

This is because the FIM completion function use multiple requests and call minuet--display-suggestion multiple times with increasing number of candidates, while inserting each new result at the first position of the candidates.

In this PR, I modifed the "push" into "append" so that each result is appended to the candidates, so that the first result user sees would not change. Only "[1/1]" would change to "[1/2]"